### PR TITLE
feat: add priority

### DIFF
--- a/src/main/java/duke/command/DeleteCommand.java
+++ b/src/main/java/duke/command/DeleteCommand.java
@@ -1,7 +1,6 @@
 package duke.command;
 
 import duke.ui.Ui;
-import duke.util.DukeException;
 import duke.util.Storage;
 import duke.util.TaskList;
 
@@ -21,7 +20,6 @@ public class DeleteCommand extends Command {
      * @param storage  Storage of Duke.
      * @param tasks Task list of Duke.
      * @param ui User interface of Duke.
-     * @throws DukeException if there is a problem updating the storage or user interface.
      */
     public String execute(Storage storage, TaskList tasks, Ui ui) {
         return ui.deleteTask(tasks.delete(index)) + ui.countTasks(tasks);

--- a/src/main/java/duke/command/EventCommand.java
+++ b/src/main/java/duke/command/EventCommand.java
@@ -2,7 +2,6 @@ package duke.command;
 
 import duke.task.Event;
 import duke.ui.Ui;
-import duke.util.DukeException;
 import duke.util.Storage;
 import duke.util.TaskList;
 
@@ -23,7 +22,6 @@ public class EventCommand extends Command {
      * @param storage  Storage of Duke.
      * @param tasks Task list of Duke.
      * @param ui User interface of Duke.
-     * @throws DukeException if there is a problem updating the storage or user interface.
      */
     public String execute(Storage storage, TaskList tasks, Ui ui) {
         tasks.add(event);

--- a/src/main/java/duke/command/FindCommand.java
+++ b/src/main/java/duke/command/FindCommand.java
@@ -1,7 +1,6 @@
 package duke.command;
 
 import duke.ui.Ui;
-import duke.util.DukeException;
 import duke.util.Storage;
 import duke.util.TaskList;
 
@@ -24,7 +23,6 @@ public class FindCommand extends Command {
      * @param storage  The storage.
      * @param tasks The list of tasks.
      * @param ui The user interface.
-     * @throws DukeException if there is a problem updating the storage or user interface.
      */
     public String execute(Storage storage, TaskList tasks, Ui ui) {
         TaskList filteredTasks = tasks.filter(keyword);

--- a/src/main/java/duke/command/ListCommand.java
+++ b/src/main/java/duke/command/ListCommand.java
@@ -1,7 +1,6 @@
 package duke.command;
 
 import duke.ui.Ui;
-import duke.util.DukeException;
 import duke.util.Storage;
 import duke.util.TaskList;
 
@@ -15,7 +14,6 @@ public class ListCommand extends Command {
      * @param storage  Storage of Duke.
      * @param tasks Task list of Duke.
      * @param ui User interface of Duke.
-     * @throws DukeException if there is a problem updating the storage or user interface.
      */
     public String execute(Storage storage, TaskList tasks, Ui ui) {
         return ui.listTasks(tasks);

--- a/src/main/java/duke/command/MarkCommand.java
+++ b/src/main/java/duke/command/MarkCommand.java
@@ -1,7 +1,6 @@
 package duke.command;
 
 import duke.ui.Ui;
-import duke.util.DukeException;
 import duke.util.Storage;
 import duke.util.TaskList;
 
@@ -21,7 +20,6 @@ public class MarkCommand extends Command {
      * @param storage  Storage of Duke.
      * @param tasks Task list of Duke.
      * @param ui User interface of Duke.
-     * @throws DukeException if there is a problem updating the storage or user interface.
      */
     public String execute(Storage storage, TaskList tasks, Ui ui) {
         tasks.mark(index);

--- a/src/main/java/duke/command/PrioritiseCommand.java
+++ b/src/main/java/duke/command/PrioritiseCommand.java
@@ -1,20 +1,25 @@
 package duke.command;
 
-import duke.task.Deadline;
 import duke.ui.Ui;
+import duke.util.Priority;
 import duke.util.Storage;
 import duke.util.TaskList;
 
-
-
 /**
- * Represents the command to add a deadline.
+ * Represents the command to mark a task as done.
  */
-public class DeadlineCommand extends Command {
-    private final Deadline deadline;
-
-    public DeadlineCommand(String description, String by) {
-        deadline = new Deadline(description, by);
+public class PrioritiseCommand extends Command {
+    private final int index;
+    private final Priority priority;
+    /**
+     * Executes the command.
+     *
+     * @param i  The task index.
+     * @param p The task priority.
+     */
+    public PrioritiseCommand(int i, Priority p) {
+        index = i;
+        priority = p;
     }
 
     /**
@@ -25,8 +30,8 @@ public class DeadlineCommand extends Command {
      * @param ui User interface of Duke.
      */
     public String execute(Storage storage, TaskList tasks, Ui ui) {
-        tasks.add(deadline);
-        return ui.addTask(deadline) + ui.countTasks(tasks);
+        tasks.prioritise(index, priority);
+        return ui.prioritiseTask(tasks.get(index));
     }
 
     /**

--- a/src/main/java/duke/command/ToDoCommand.java
+++ b/src/main/java/duke/command/ToDoCommand.java
@@ -2,7 +2,6 @@ package duke.command;
 
 import duke.task.ToDo;
 import duke.ui.Ui;
-import duke.util.DukeException;
 import duke.util.Storage;
 import duke.util.TaskList;
 
@@ -23,7 +22,6 @@ public class ToDoCommand extends Command {
      * @param storage  Storage of Duke.
      * @param tasks Task list of Duke.
      * @param ui User interface of Duke.
-     * @throws DukeException if there is a problem updating the storage or user interface.
      */
     public String execute(Storage storage, TaskList tasks, Ui ui) {
         tasks.add(toDo);

--- a/src/main/java/duke/command/UnmarkCommand.java
+++ b/src/main/java/duke/command/UnmarkCommand.java
@@ -1,7 +1,6 @@
 package duke.command;
 
 import duke.ui.Ui;
-import duke.util.DukeException;
 import duke.util.Storage;
 import duke.util.TaskList;
 
@@ -22,7 +21,6 @@ public class UnmarkCommand extends Command {
      * @param storage  Storage of Duke.
      * @param tasks Task list of Duke.
      * @param ui User interface of Duke.
-     * @throws DukeException if there is a problem updating the storage or user interface.
      */
     public String execute(Storage storage, TaskList tasks, Ui ui) {
         tasks.unmark(index);

--- a/src/main/java/duke/gui/controller/MainWindow.java
+++ b/src/main/java/duke/gui/controller/MainWindow.java
@@ -1,5 +1,7 @@
 package duke.gui.controller;
 
+import java.util.Objects;
+
 import duke.Duke;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
@@ -24,8 +26,10 @@ public class MainWindow extends AnchorPane {
 
     private Duke duke;
 
-    private final Image userImage = new Image(this.getClass().getResourceAsStream("/images/DaUser.png"));
-    private final Image dukeImage = new Image(this.getClass().getResourceAsStream("/images/DaDuke.png"));
+    private final Image userImage = new Image(Objects.requireNonNull(
+            this.getClass().getResourceAsStream("/images/DaUser.png")));
+    private final Image dukeImage = new Image(Objects.requireNonNull(
+            this.getClass().getResourceAsStream("/images/DaDuke.png")));
 
     @FXML
     public void initialize() {

--- a/src/main/java/duke/task/Deadline.java
+++ b/src/main/java/duke/task/Deadline.java
@@ -3,6 +3,9 @@ package duke.task;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+import duke.util.Priority;
+import duke.util.Status;
+
 /**
  * Represents a deadline.
  */
@@ -10,16 +13,24 @@ public class Deadline extends Task {
     private final LocalDateTime by;
     /**
      * Constructs a deadline.
-     * @param description The deadline description.
-     * @param by The deadline date and time.
+     * @param d The deadline description.
+     * @param s The deadline status.
+     * @param p The deadline priority.
+     * @param b The deadline datetime.
      */
-    public Deadline(String description, String by, boolean isDone) {
-        super(description, isDone);
-        this.by = LocalDateTime.parse(by, DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm"));
+    public Deadline(String d, Status s, Priority p, String b) {
+        super(d, s, p);
+        by = parseDateTime(b);
     }
 
-    public Deadline(String description, String by) {
-        this(description, by, false);
+    /**
+     * Constructs a deadline.
+     * @param d The deadline description.
+     * @param b The deadline datetime.
+     */
+    public Deadline(String d, String b) {
+        super(d);
+        by = parseDateTime(b);
     }
 
     /**
@@ -30,7 +41,7 @@ public class Deadline extends Task {
     @Override
     public String save() {
         String dateTime = by.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm"));
-        return "D | " + super.save() + " | " + dateTime + System.lineSeparator();
+        return "D | " + super.save() + " | " + dateTime + " | " + savePriority() + "\n";
     }
 
     /**
@@ -41,6 +52,6 @@ public class Deadline extends Task {
     @Override
     public String toString() {
         String dateTime = by.format(DateTimeFormatter.ofPattern("MMM d yyyy HHmm"));
-        return "[D]" + super.toString() + " (by: " + dateTime + ")" + "\n";
+        return "[D]" + super.toString() + " (by " + dateTime + ")\n";
     }
 }

--- a/src/main/java/duke/task/Event.java
+++ b/src/main/java/duke/task/Event.java
@@ -3,6 +3,9 @@ package duke.task;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+import duke.util.Priority;
+import duke.util.Status;
+
 /**
  * Represents an event with a date and time.
  */
@@ -11,17 +14,24 @@ public class Event extends Task {
 
     /**
      * Constructs an event.
-     * @param description The event description.
-     * @param at The event date and time.
-     * @param isDone The event status, whether it is done or not.
+     * @param d The event description.
+     * @param s The event status.
+     * @param p The event priority.
+     * @param a The event datetime.
      */
-    public Event(String description, String at, boolean isDone) {
-        super(description, isDone);
-        this.at = LocalDateTime.parse(at, DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm"));
+    public Event(String d, Status s, Priority p, String a) {
+        super(d, s, p);
+        at = parseDateTime(a);
     }
 
-    public Event(String description, String at) {
-        this(description, at, false);
+    /**
+     * Constructs an event with unspecified status and priority, which defaults to NOT_DONE and MEDIUM respectively.
+     * @param d The event description.
+     * @param a The event datetime.
+     */
+    public Event(String d, String a) {
+        super(d);
+        at = parseDateTime(a);
     }
 
     /**
@@ -31,7 +41,7 @@ public class Event extends Task {
     @Override
     public String save() {
         String dateTime = at.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm"));
-        return "E | " + super.save() + " | " + dateTime + System.lineSeparator();
+        return "E | " + super.save() + " | " + dateTime + " | " + savePriority() + "\n";
     }
 
     /**
@@ -41,6 +51,6 @@ public class Event extends Task {
     @Override
     public String toString() {
         String dateTime = at.format(DateTimeFormatter.ofPattern("MMM d yyyy HHmm"));
-        return "[E]" + super.toString() + " (at: " + dateTime + ")" + "\n";
+        return "[E]" + super.toString() + " (at " + dateTime + ")\n";
     }
 }

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -1,23 +1,44 @@
 package duke.task;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import duke.util.Priority;
+import duke.util.Status;
+
 /**
  * Represents a task.
  */
 public class Task {
-    protected final String description;
-    protected boolean isDone;
+    private final String description;
+    private Status status;
+    private Priority priority;
     /**
      * Constructs a task.
-     * @param description The task description.
-     * @param isDone The task status e.g. whether it is done or not.
+     * @param d The task description.
+     * @param s The task status.
+     * @param p The task priority.
      */
-    public Task(String description, boolean isDone) {
-        this.description = description;
-        this.isDone = isDone;
+    public Task(String d, Status s, Priority p) {
+        description = d;
+        status = s;
+        priority = p;
     }
 
-    public Task(String description) {
-        this(description, false);
+    /**
+     * Constructs a task with unspecified status, which defaults to NOT_DONE.
+     * @param d The task description.
+     * @param p The task priority.
+     */
+    public Task(String d, Priority p) {
+        this(d, Status.NOT_DONE, p);
+    }
+    /**
+     * Constructs a task with unspecified status and priority, which defaults to NOT_DONE and MEDIUM respectively.
+     * @param d The task description.
+     */
+    public Task(String d) {
+        this(d, Status.NOT_DONE, Priority.MEDIUM);
     }
 
     public String getDescription() {
@@ -25,27 +46,51 @@ public class Task {
     }
 
     /**
-     * Returns a string X indicating whether the task is done or not.
+     * Returns the task status as a string.
      *
-     * @return String X indicating whether the task is done or not.
+     * @return "X" if the task is done, and " " if it is not.
      */
-    public String getStatusIcon() {
-        return (isDone ? "X" : " "); // mark done task with X
+    public String statusToString() {
+        return (status == Status.DONE ? "X" : " ");
     }
 
     /**
-     * Marks the task as done.
+     * Return the task priority as a string.
      *
+     * @return The task priority as a string.
      */
-    public void markAsDone() {
-        isDone = true;
+    public String priorityToString() {
+        switch (priority) {
+        case LOW:
+            return "Low";
+        case HIGH:
+            return "High";
+        default:
+            return "Medium";
+        }
     }
 
     /**
-     * Marks the task as not done.
+     * Changing the task status to DONE.
+     *
      */
-    public void markAsNotDone() {
-        isDone = false;
+    public void mark() {
+        status = Status.DONE;
+    }
+
+    /**
+     * Changes the task status to NOT_DONE.
+     */
+    public void unmark() {
+        status = Status.NOT_DONE;
+    }
+
+    /**
+     * Sets the task priority.
+     * @param p The task priority.
+     */
+    public void prioritise(Priority p) {
+        priority = p;
     }
 
     /**
@@ -55,10 +100,26 @@ public class Task {
      */
     public String save() {
         int s = 0;
-        if (isDone) {
+        if (status == Status.DONE) {
             s = 1;
         }
         return s + " | " + description;
+    }
+
+    /**
+     * Returns the task priority as a string to be saved.
+     *
+     * @return The task priority as a string to be saved.
+     */
+    public String savePriority() {
+        switch(priority) {
+        case LOW:
+            return "0";
+        case HIGH:
+            return "2";
+        default:
+            return "1";
+        }
     }
 
     /**
@@ -68,6 +129,10 @@ public class Task {
      */
     @Override
     public String toString() {
-        return "[" + getStatusIcon() + "] " + description;
+        return "[" + priorityToString() + "]" + "[" + statusToString() + "] " + description;
+    }
+
+    public LocalDateTime parseDateTime(String s) {
+        return LocalDateTime.parse(s, DateTimeFormatter.ofPattern("yyyy-MM-dd HHmm"));
     }
 }

--- a/src/main/java/duke/task/ToDo.java
+++ b/src/main/java/duke/task/ToDo.java
@@ -1,15 +1,28 @@
 package duke.task;
 
+import duke.util.Priority;
+import duke.util.Status;
+
 /**
  * Represents a to-do item.
  */
 public class ToDo extends Task {
-    public ToDo(String description) {
-        super(description);
+    /**
+     * Constructs a to-do.
+     * @param d The event description.
+     * @param s The event status.
+     * @param p The event priority.
+     */
+    public ToDo(String d, Status s, Priority p) {
+        super(d, s, p);
     }
 
-    public ToDo(String description, boolean isDone) {
-        super(description, isDone);
+    /**
+     * Constructs a to-do with unspecified status and priority, which defaults to NOT_DONE and MEDIUM respectively.
+     * @param d The event description.
+     */
+    public ToDo(String d) {
+        super(d);
     }
 
     /**
@@ -19,7 +32,7 @@ public class ToDo extends Task {
      */
     @Override
     public String save() {
-        return "T | " + super.save() + System.lineSeparator();
+        return "T | " + super.save() + " | " + savePriority() + "\n";
     }
 
     /**

--- a/src/main/java/duke/ui/Ui.java
+++ b/src/main/java/duke/ui/Ui.java
@@ -106,6 +106,14 @@ public class Ui {
     }
 
     /**
+     * Displays the task whose priority has been changed.
+     * @param task The task whose priority has been changed.
+     */
+    public String prioritiseTask(Task task) {
+        return "Got it, I've changed the priority of this task:\n" + task;
+    }
+
+    /**
      * Saves tasks to storage and displays farewell message.
      * @param storage Storage.
      * @param tasks Tasks to be saved.

--- a/src/main/java/duke/util/Parser.java
+++ b/src/main/java/duke/util/Parser.java
@@ -8,6 +8,7 @@ import duke.command.EventCommand;
 import duke.command.FindCommand;
 import duke.command.ListCommand;
 import duke.command.MarkCommand;
+import duke.command.PrioritiseCommand;
 import duke.command.ToDoCommand;
 import duke.command.UnmarkCommand;
 
@@ -28,7 +29,7 @@ public class Parser {
         case "list":
             return new ListCommand();
         case "todo":
-            throw new DukeException("OOPS!!! The description of a todo cannot be empty.");
+            throw new DukeException("The description of a todo cannot be empty.");
         default:
             String[] commandArr = fullCommand.split(" ");
             if (commandArr.length > 1) {
@@ -54,6 +55,9 @@ public class Parser {
                         return new UnmarkCommand(index);
                     case "delete":
                         return new DeleteCommand(index);
+                    case "prioritise":
+                        Priority priority = parsePriority(commandArr[2]);
+                        return new PrioritiseCommand(index, priority);
                     default:
                         throw new DukeException("Sorry, but I don't know what that means :-(");
                     }
@@ -61,6 +65,21 @@ public class Parser {
             } else {
                 throw new DukeException("Sorry, but I don't know what that means :-(");
             }
+        }
+    }
+    /**
+     * Parses the input into a task priority.
+     * @param s The input.
+     * @return A task priority.
+     */
+    public static Priority parsePriority(String s) {
+        switch(s) {
+        case "low":
+            return Priority.LOW;
+        case "high":
+            return Priority.HIGH;
+        default:
+            return Priority.MEDIUM;
         }
     }
 }

--- a/src/main/java/duke/util/Priority.java
+++ b/src/main/java/duke/util/Priority.java
@@ -1,0 +1,7 @@
+package duke.util;
+
+public enum Priority {
+    LOW,
+    MEDIUM,
+    HIGH
+}

--- a/src/main/java/duke/util/Status.java
+++ b/src/main/java/duke/util/Status.java
@@ -1,0 +1,6 @@
+package duke.util;
+
+public enum Status {
+    DONE,
+    NOT_DONE
+}

--- a/src/main/java/duke/util/Storage.java
+++ b/src/main/java/duke/util/Storage.java
@@ -37,19 +37,20 @@ public class Storage {
                 String fullCommand = sc.nextLine();
                 String[] commandArr = fullCommand.split(" \\| ");
                 String type = commandArr[0];
-                boolean status = (Integer.parseInt(commandArr[1]) == 1);
+                Status status = parseStatus(commandArr[1]);
                 String description = commandArr[2];
+                Priority priority = parsePriority(commandArr[commandArr.length - 1]);
                 switch (type) {
                 case "E":
                     String at = commandArr[3];
-                    tasks.add(new Event(description, at, status));
+                    tasks.add(new Event(description, status, priority, at));
                     break;
                 case "D":
                     String by = commandArr[3];
-                    tasks.add(new Deadline(description, by, status));
+                    tasks.add(new Deadline(description, status, priority, by));
                     break;
                 case "T":
-                    tasks.add(new ToDo(description, status));
+                    tasks.add(new ToDo(description, status, priority));
                     break;
                 default:
                     break;
@@ -77,6 +78,34 @@ public class Storage {
             fw.close();
         } catch (IOException e) {
             throw new DukeException(e.getMessage());
+        }
+    }
+
+    /**
+     * Parses a string to a task status.
+     * @param s The task status as a string.
+     */
+    public Status parseStatus(String s) {
+        int i = Integer.parseInt(s);
+        if (i == 0) {
+            return Status.NOT_DONE;
+        }
+        return Status.DONE;
+    }
+
+    /**
+     * Parses a string to a task priority.
+     * @param s The task priority as a string.
+     */
+    public Priority parsePriority(String s) {
+        int i = Integer.parseInt(s);
+        switch(i) {
+        case 0:
+            return Priority.LOW;
+        case 2:
+            return Priority.HIGH;
+        default:
+            return Priority.MEDIUM;
         }
     }
 }

--- a/src/main/java/duke/util/TaskList.java
+++ b/src/main/java/duke/util/TaskList.java
@@ -9,17 +9,19 @@ import duke.task.Task;
  */
 public class TaskList {
     private final ArrayList<Task> tasks;
-
-    public TaskList(ArrayList<Task> tasks) {
-        this.tasks = tasks;
+    /**
+     * Constructs a task list.
+     * @param t An ArrayList of tasks.
+     */
+    public TaskList(ArrayList<Task> t) {
+        tasks = t;
     }
 
+    /**
+     * Constructs an empty task list.
+     */
     public TaskList() {
         this(new ArrayList<>());
-    }
-
-    public Task get(int i) {
-        return tasks.get(i);
     }
 
     public boolean isEmpty() {
@@ -30,16 +32,20 @@ public class TaskList {
         return tasks.size();
     }
 
+    public Task get(int i) {
+        return tasks.get(i);
+    }
+
     public void add(Task task) {
         tasks.add(task);
     }
 
     public void mark(int index) {
-        tasks.get(index).markAsDone();
+        tasks.get(index).mark();
     }
 
     public void unmark(int index) {
-        tasks.get(index).markAsNotDone();
+        tasks.get(index).unmark();
     }
     /**
      * Deletes a task.
@@ -49,6 +55,14 @@ public class TaskList {
         Task task = tasks.get(index);
         tasks.remove(index);
         return task;
+    }
+    /**
+     * Changes the priority of a task.
+     * @param i The index of the task in the task list.
+     * @param p The priority to set the task to.
+     */
+    public void prioritise(int i, Priority p) {
+        tasks.get(i).prioritise(p);
     }
     /**
      * Filter the tasks according to a keyword.

--- a/src/main/resources/view/DialogBox.fxml
+++ b/src/main/resources/view/DialogBox.fxml
@@ -4,7 +4,6 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.HBox?>
-
 <fx:root alignment="CENTER_RIGHT" spacing="15" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308"
          prefWidth="400.0" type="javafx.scene.layout.HBox" xmlns="http://javafx.com/javafx/8.0.171"
          xmlns:fx="http://javafx.com/fxml/1">

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -5,7 +5,6 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.VBox?>
-
 <AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="600.0"
             prefWidth="400.0" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="duke.gui.controller.MainWindow">

--- a/src/test/java/duke/ParserTest.java
+++ b/src/test/java/duke/ParserTest.java
@@ -27,7 +27,7 @@ public class ParserTest {
             assertEquals("foo", Parser.parse("todo"));
             fail();
         } catch (DukeException e) {
-            assertEquals("OOPS!!! The description of a todo cannot be empty.", e.getMessage());
+            assertEquals("The description of a todo cannot be empty.", e.getMessage());
         }
     }
 }


### PR DESCRIPTION
There is no way to set priority levels for tasks.

Being able to set a priority level for each task will allow users to
note down which tasks are more urgent and therefore should be done first.

Let's add the ability to set a priority level for each task by
integrating into the `Task` class a `Priority` enum with three values:
* `LOW`
* `MEDIUM`
* `HIGH`

Using an enum is suitable because priority levels can be defined as a
set of predefined values, and using it over, say, a range of integer
values will also make the code easier to understand.

Refer to this website for more information on enum types:
https://docs.oracle.com/javase/tutorial/java/javaOO/enum.html